### PR TITLE
Exclude Makefiles from tab hooks by default

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -16,6 +16,7 @@
     entry: forbid_tabs
     language: python
     files: ''
+    exclude: (Makefile|debian/rules)(\.in)?$
 -   id: remove-tabs
     name: Tabs remover
     description: "Replace tabs by whitespaces before committing"
@@ -23,3 +24,4 @@
     args: [ --whitespaces-count, '4' ]
     language: python
     files: ''
+    exclude: (Makefile|debian/rules)(\.in)?$


### PR DESCRIPTION
Makefiles have a strict requirement on actual tabs, so I think it makes sense to exclude them by default here. (Also excludes `debian/rules` which is actually a Makefile.)

This can still be overridden if for some reason a user of the hook wants to have broken Makefiles -shrug-