### PR TITLE
Add support for Python 3 to is_textfile

### DIFF
--- a/pre_commit_hooks/utils.py
+++ b/pre_commit_hooks/utils.py
@@ -8,14 +8,17 @@ ALLOWED_NON_PRINTABLE_THRESHOLD = 0.15
 def is_textfile(filename, blocksize=512):
     if any(filename.endswith(ext) for ext in KNOWN_BINARY_FILE_EXT):
         return False
-    return is_text(open(filename).read(blocksize))
+    return is_text(open(filename, 'rb').read(blocksize))
 
 def is_text(stuff):
-    if "\0" in stuff:
+    if b"\0" in stuff:
         return False
     if not stuff:  # Empty files are considered text
         return True
-    # Get the non-text characters (maps a character to itself then
-    # use the 'remove' option to get rid of the text characters.)
-    non_printable_chars = ''.join(c for c in stuff if c not in string.printable)
-    return len(non_printable_chars) / len(stuff) < ALLOWED_NON_PRINTABLE_THRESHOLD
+    # Try to decode as UTF-8
+    try:
+        stuff.decode('utf8')
+    except UnicodeDecodeError:
+        return False
+    else:
+        return True


### PR DESCRIPTION
Makes `is_textfile()` (and therefore `forbid-crlf` and `forbid-tabs`) work on both Python 2 and 3.

I've changed the heuristic; it didn't make sense to check a byte string for 'printable characters', so I've made it return `True` for any file that decodes as UTF-8, which I figured should cover most source code files. I could re-add the printable character check, but I figured it'd be pretty unlikely that a binary file would successfully decode as UTF-8 in the first place.