### PR TITLE
doc: use https:// instead of git:// to use these hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Hooks that require Python dependencies, or specific to a language, have been ext
 
 ## Usage
 
-    -   repo: git://github.com/Lucas-C/pre-commit-hooks
+    -   repo: https://github.com/Lucas-C/pre-commit-hooks
         sha: v1.1.4
         hooks:
         -   id: forbid-crlf


### PR DESCRIPTION
git protocol provides no verification of the server and is
often blocked in corporate environments.

https protocol is usually available and works with proxies.