### PR TITLE
fix: escape dot in gitmodules

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -16,7 +16,7 @@
     entry: forbid_tabs
     language: python
     files: ''
-    exclude: (Makefile|debian/rules|.gitmodules)(\.in)?$
+    exclude: (Makefile|debian/rules|\.gitmodules)(\.in)?$
 -   id: remove-tabs
     name: Tabs remover
     description: "Replace tabs by whitespaces before committing"
@@ -24,4 +24,4 @@
     language: python
     args: [ --whitespaces-count, '4' ]
     files: ''
-    exclude: (Makefile|debian/rules|.gitmodules)(\.in)?$
+    exclude: (Makefile|debian/rules|\.gitmodules)(\.in)?$


### PR DESCRIPTION
It is better to be more exact here. _Possible_ fix for continued issue in #14 - I don't really understand why "." does't match a ".", though, a dot is a character.