### PR TITLE
Use the wheels version of Levenshtein for Window compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages('.'),
     install_requires=[
         'fuzzywuzzy',
-        'python-Levenshtein'
+        'python-Levenshtein-wheels'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
We started using the remove-tabs hook at Earnest and we have contributors on Windows/Mac/Linux

On my Mac I don't have issues but we have someone on Windows that hit the following:

```
[INFO] Installing environment for https://github.com/Lucas-C/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('C:\\Users\\user\\.cache\\pre-commit\\repo5f2zz_fa\\py_env-python3.8\\Scripts\\python.EXE', '-mpip', 'install', '.', 'python-Levenshtein-wheels')
return code: 1
expected return code: 0
stdout:
    Processing c:\users\user\.cache\pre-commit\repo5f2zz_fa
    Collecting python-Levenshtein-wheels
      Using cached python_Levenshtein_wheels-0.13.1-cp38-cp38-win32.whl (43 kB)
    Collecting fuzzywuzzy
      Using cached fuzzywuzzy-0.18.0-py2.py3-none-any.whl (18 kB)
    Collecting python-Levenshtein
      Using cached python-Levenshtein-0.12.1.tar.gz (50 kB)
    Requirement already satisfied: setuptools in c:\users\user\.cache\pre-commit\repo5f2zz_fa\py_env-python3.8\lib\site-packages (from python-Levenshtein->pre-commit-hooks==1.1.9) (46.1.3)
    Building wheels for collected packages: pre-commit-hooks, python-Levenshtein
      Building wheel for pre-commit-hooks (setup.py): started
      Building wheel for pre-commit-hooks (setup.py): finished with status 'done'
      Created wheel for pre-commit-hooks: filename=pre_commit_hooks-1.1.9-py3-none-any.whl size=13015 sha256=3380dff37e101dbe9eefc9acddcd46d7436eb31e3c94df8efa99fbc64590d55f
      Stored in directory: C:\Users\user\AppData\Local\Temp\pip-ephem-wheel-cache-78h0did3\wheels\7e\cc\42\82e57d7fd5367ceb443e67878a7dd12353470ce024d3d68cba
      Building wheel for python-Levenshtein (setup.py): started
      Building wheel for python-Levenshtein (setup.py): finished with status 'error'
      Running setup.py clean for python-Levenshtein
    Successfully built pre-commit-hooks
    Failed to build python-Levenshtein
    Installing collected packages: python-Levenshtein-wheels, fuzzywuzzy, python-Levenshtein, pre-commit-hooks
        Running setup.py install for python-Levenshtein: started
        Running setup.py install for python-Levenshtein: finished with status 'error'
stderr:
      ERROR: Command errored out with exit status 1:
       command: 'C:\Users\user\.cache\pre-commit\repo5f2zz_fa\py_env-python3.8\Scripts\python.EXE' -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\user\\AppData\\Local\\Temp\\pip-install-nz9w0e1o\\python-Levenshtein\\setup.py'"'"'; __file__='"'"'C:\\Users\\user\\AppData\\Local\\Temp\\pip-install-nz9w0e1o\\python-Levenshtein\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d 'C:\Users\user\AppData\Local\Temp\pip-wheel-lagmho9r'
           cwd: C:\Users\user\AppData\Local\Temp\pip-install-nz9w0e1o\python-Levenshtein\
      Complete output (27 lines):
      running bdist_wheel
      running build
      running build_py
      creating build
      creating build\lib.win32-3.8
      creating build\lib.win32-3.8\Levenshtein
      copying Levenshtein\StringMatcher.py -> build\lib.win32-3.8\Levenshtein
      copying Levenshtein\__init__.py -> build\lib.win32-3.8\Levenshtein
      running egg_info
      writing python_Levenshtein.egg-info\PKG-INFO
      writing dependency_links to python_Levenshtein.egg-info\dependency_links.txt
      writing entry points to python_Levenshtein.egg-info\entry_points.txt
      writing namespace_packages to python_Levenshtein.egg-info\namespace_packages.txt
      writing requirements to python_Levenshtein.egg-info\requires.txt
      writing top-level names to python_Levenshtein.egg-info\top_level.txt
      reading manifest file 'python_Levenshtein.egg-info\SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      warning: no previously-included files matching '*pyc' found anywhere in distribution
      warning: no previously-included files matching '*so' found anywhere in distribution
      warning: no previously-included files matching '.project' found anywhere in distribution
      warning: no previously-included files matching '.pydevproject' found anywhere in distribution
      writing manifest file 'python_Levenshtein.egg-info\SOURCES.txt'
      copying Levenshtein\_levenshtein.c -> build\lib.win32-3.8\Levenshtein
      copying Levenshtein\_levenshtein.h -> build\lib.win32-3.8\Levenshtein
      running build_ext
      building 'Levenshtein._levenshtein' extension
      error: Microsoft Visual C++ 14.0 is required. Get it with "Build Tools for Visual Studio": https://visualstudio.microsoft.com/downloads/
      ----------------------------------------
      ERROR: Failed building wheel for python-Levenshtein
        ERROR: Command errored out with exit status 1:
         command: 'C:\Users\user\.cache\pre-commit\repo5f2zz_fa\py_env-python3.8\Scripts\python.EXE' -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\user\\AppData\\Local\\Temp\\pip-install-nz9w0e1o\\python-Levenshtein\\setup.py'"'"'; __file__='"'"'C:\\Users\\user\\AppData\\Local\\Temp\\pip-install-nz9w0e1o\\python-Levenshtein\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record 'C:\Users\user\AppData\Local\Temp\pip-record-cl64xe53\install-record.txt' --single-version-externally-managed --compile --install-headers 'C:\Users\user\.cache\pre-commit\repo5f2zz_fa\py_env-python3.8\include\site\python3.8\python-Levenshtein'
             cwd: C:\Users\user\AppData\Local\Temp\pip-install-nz9w0e1o\python-Levenshtein\
        Complete output (27 lines):
        running install
        running build
        running build_py
        creating build
        creating build\lib.win32-3.8
        creating build\lib.win32-3.8\Levenshtein
        copying Levenshtein\StringMatcher.py -> build\lib.win32-3.8\Levenshtein
        copying Levenshtein\__init__.py -> build\lib.win32-3.8\Levenshtein
        running egg_info
        writing python_Levenshtein.egg-info\PKG-INFO
        writing dependency_links to python_Levenshtein.egg-info\dependency_links.txt
        writing entry points to python_Levenshtein.egg-info\entry_points.txt
        writing namespace_packages to python_Levenshtein.egg-info\namespace_packages.txt
        writing requirements to python_Levenshtein.egg-info\requires.txt
        writing top-level names to python_Levenshtein.egg-info\top_level.txt
        reading manifest file 'python_Levenshtein.egg-info\SOURCES.txt'
        reading manifest template 'MANIFEST.in'
        warning: no previously-included files matching '*pyc' found anywhere in distribution
        warning: no previously-included files matching '*so' found anywhere in distribution
        warning: no previously-included files matching '.project' found anywhere in distribution
        warning: no previously-included files matching '.pydevproject' found anywhere in distribution
        writing manifest file 'python_Levenshtein.egg-info\SOURCES.txt'
        copying Levenshtein\_levenshtein.c -> build\lib.win32-3.8\Levenshtein
        copying Levenshtein\_levenshtein.h -> build\lib.win32-3.8\Levenshtein
        running build_ext
        building 'Levenshtein._levenshtein' extension
        error: Microsoft Visual C++ 14.0 is required. Get it with "Build Tools for Visual Studio": https://visualstudio.microsoft.com/downloads/
        ----------------------------------------
    ERROR: Command errored out with exit status 1: 'C:\Users\user\.cache\pre-commit\repo5f2zz_fa\py_env-python3.8\Scripts\python.EXE' -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\user\\AppData\\Local\\Temp\\pip-install-nz9w0e1o\\python-Levenshtein\\setup.py'"'"'; __file__='"'"'C:\\Users\\user\\AppData\\Local\\Temp\\pip-install-nz9w0e1o\\python-Levenshtein\\setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record 'C:\Users\user\AppData\Local\Temp\pip-record-cl64xe53\install-record.txt' --single-version-externally-managed --compile --install-headers 'C:\Users\user\.cache\pre-commit\repo5f2zz_fa\py_env-python3.8\include\site\python3.8\python-Levenshtein' Check the logs for full command output.
Check the log at C:\Users\user\.cache\pre-commit\pre-commit.log
```

Just changing the Levenshtein dependency to use -wheels allows us to use the hook on both Mac and Windows