### PR TITLE
Add --no-space option and do no add space when --comment-style arg is empty string #29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 /pre_commit_hooks.egg-info
 /.cache/
 /.idea/
-/.coverage
+**/.coverage
 /venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: remove-tabs
         exclude: tests/resources/main.*_with_license.cpp
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: trailing-whitespace
         files: ''

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-exclude: ^(\.[^/]*cache(__)?/.*)$
+exclude: ^(\.[^/]*cache(__)?/.*|\.coverage)$
 repos:
   - repo: https://github.com/executablebooks/mdformat
     # Do this before other tools "fixing" the line endings
@@ -71,7 +71,7 @@ repos:
         name: py.test
         language: python
         additional_dependencies: [pytest, pytest-cov, coverage, fuzzywuzzy, python-Levenshtein-wheels]
-        entry: sh
+        entry: pytest -sv
         require_serial: true
         pass_filenames: false
         files: \.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,35 +1,48 @@
+---
 repos:
--   repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/executablebooks/mdformat
+    # Do this before other tools "fixing" the line endings
+    rev: 0.7.14
+    hooks:
+      - id: mdformat
+        name: Format Markdown
+        entry: mdformat  # Executable to run, with fixed options
+        language: python
+        types: [markdown]
+        args: [--wrap, '75', --number]
+        additional_dependencies:
+          - mdformat-toc
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.13
     hooks:
-    -   id: forbid-crlf
-    -   id: remove-crlf
-    -   id: forbid-tabs
+      - id: forbid-crlf
+      - id: remove-crlf
+      - id: forbid-tabs
         exclude: tests/resources/main.*_with_license.cpp
-    -   id: remove-tabs
+      - id: remove-tabs
         exclude: tests/resources/main.*_with_license.cpp
--   repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0
     hooks:
-    -   id: trailing-whitespace
+      - id: trailing-whitespace
         files: ''
         exclude: tests/resources/main.*_with_license.cpp
-    -   id: check-yaml
--   repo: git://github.com/pre-commit/mirrors-pylint
+      - id: check-yaml
+  - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v3.0.0a4
     hooks:
-    -   id: pylint
+      - id: pylint
         args:
-        - --rcfile=.pylintrc
-        - --reports=no
+          - --rcfile=.pylintrc
+          - --reports=no
         exclude: ^tests/resources/.*(init_with_license\.py|todo).*$
--   repo: local
+  - repo: local
     hooks:
-    -   id: py.test
+      - id: py.test
         name: py.test
         language: python
-        additional_dependencies: ['pytest', 'pytest-cov', 'coverage', 'fuzzywuzzy', 'python-Levenshtein-wheels']
+        additional_dependencies: [pytest, pytest-cov, coverage, fuzzywuzzy, python-Levenshtein-wheels]
         entry: sh
         require_serial: true
         pass_filenames: false
-        files: '\.py$'
+        files: \.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ---
+exclude: ^(\.[^/]*cache(__)?/.*)$
 repos:
   - repo: https://github.com/executablebooks/mdformat
     # Do this before other tools "fixing" the line endings
@@ -28,6 +29,9 @@ repos:
         files: ''
         exclude: tests/resources/main.*_with_license.cpp
       - id: check-yaml
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v3.0.0a4
     hooks:
@@ -36,6 +40,31 @@ repos:
           - --rcfile=.pylintrc
           - --reports=no
         exclude: ^tests/resources/.*(init_with_license\.py|todo).*$
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        stages: [manual]   # Skip in automated run for now
+        args:
+          - --safe
+          - --quiet
+        exclude: ^tests/resources/.*(init_with_license\.py|todo).*$
+  - repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
+    rev: v1.0.6
+    hooks:
+      - id: python-bandit-vulnerability-check
+        args: [--skip, 'B101', --recursive, .]   # Example for skipping rule
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.942
+    hooks:
+      - id: mypy
+        args:
+          - --ignore-missing-imports
+          - --install-types
+          - --non-interactive
+          - --check-untyped-defs
+          - --show-error-codes
+          - --show-error-context
   - repo: local
     hooks:
       - id: py.test

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A few useful git hooks to integrate with
 [pre-commit](http://pre-commit.com).
 
-<!-- toc -->
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=3 --minlevel=1 -->
 
 - [Usage](#usage)
   - [insert-license](#insert-license)
@@ -15,10 +15,10 @@ A few useful git hooks to integrate with
   - [Forbid some Javascript keywords for browser retrocompatibility issues](#forbid-some-javascript-keywords-for-browser-retrocompatibility-issues)
   - [CSS](#css)
   - [Some Angular 1.5 checks](#some-angular-15-checks)
+- [Development](#development)
+  - [Releasing a new version](#releasing-a-new-version)
 
-<!-- tocstop -->
-
-# Introduction
+<!-- mdformat-toc end -->
 
 Hooks specific to a language, or with more dependencies have been extracted
 into separate repos:

--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
 [![build status](https://github.com/Lucas-C/pre-commit-hooks/workflows/CI/badge.svg)](https://github.com/Lucas-C/pre-commit-hooks/actions?query=branch%3Amaster)
 
-A few useful git hooks to integrate with [pre-commit](http://pre-commit.com).
+A few useful git hooks to integrate with
+[pre-commit](http://pre-commit.com).
 
 <!-- toc -->
 
 - [Usage](#usage)
-  * [insert-license](#insert-license)
+  - [insert-license](#insert-license)
 - [Handy shell functions](#handy-shell-functions)
 - [Useful local hooks](#useful-local-hooks)
-  * [Forbid / remove some unicode characters](#forbid--remove-some-unicode-characters)
-  * [Bash syntax validation](#bash-syntax-validation)
-  * [For Groovy-like Jenkins pipelines](#for-groovy-like-jenkins-pipelines)
-  * [Forbid some Javascript keywords for browser retrocompatibility issues](#forbid-some-javascript-keywords-for-browser-retrocompatibility-issues)
-  * [CSS](#css)
-  * [Some Angular 1.5 checks](#some-angular-15-checks)
+  - [Forbid / remove some unicode characters](#forbid--remove-some-unicode-characters)
+  - [Bash syntax validation](#bash-syntax-validation)
+  - [For Groovy-like Jenkins pipelines](#for-groovy-like-jenkins-pipelines)
+  - [Forbid some Javascript keywords for browser retrocompatibility issues](#forbid-some-javascript-keywords-for-browser-retrocompatibility-issues)
+  - [CSS](#css)
+  - [Some Angular 1.5 checks](#some-angular-15-checks)
 
 <!-- tocstop -->
 
-Hooks specific to a language, or with more dependencies have been extracted into separate repos:
+# Introduction
+
+Hooks specific to a language, or with more dependencies have been extracted
+into separate repos:
 
 - https://github.com/Lucas-C/pre-commit-hooks-bandit
 - https://github.com/Lucas-C/pre-commit-hooks-go
@@ -29,78 +33,95 @@ Hooks specific to a language, or with more dependencies have been extracted into
 
 ## Usage
 
-    -   repo: https://github.com/Lucas-C/pre-commit-hooks
-        rev: v1.1.13
-        hooks:
-        -   id: forbid-crlf
-        -   id: remove-crlf
-        -   id: forbid-tabs
-        -   id: remove-tabs
-            args: [ '--whitespaces-count', '2' ]  # defaults to: 4
-        -   id: insert-license
-            files: \.groovy$
-            args:
-            - --license-filepath
-            - src/license_header.txt          # defaults to: LICENSE.txt
-            - --comment-style
-            - //                              # defaults to: #
+```yaml
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.1.13
+  hooks:
+    - id: forbid-crlf
+    - id: remove-crlf
+    - id: forbid-tabs
+    - id: remove-tabs
+      args: [--whitespaces-count, '2']  # defaults to: 4
+    - id: insert-license
+      files: \.groovy$
+      args:
+        - --license-filepath
+        - src/license_header.txt        # defaults to: LICENSE.txt
+        - --comment-style
+        - //                            # defaults to:  #
+```
 
 ### insert-license
 
 #### Comment styles
 
 The following styles can be used for example:
-* For Java / Javascript / CSS/ C / C++ (multi-line comments) set `/*| *| */`.
-* For Java / Javascript / CSS/ C / C++ (single line comments) set `//`.
-* For HTML files: `<!--|  ~|  -->`.
-* For Python: `#`
-* For Jinja templates: `'{#||#}'`
+
+- For Java / Javascript / CSS/ C / C++ (multi-line comments) set
+  `/*| *| */` ;
+- For Java / Javascript / CSS/ C / C++ (single line comments) set `//` ;
+- For HTML files: `<!--|  ~|  -->` ;
+- For Python: `#` ;
+- For Jinja templates: `'{#||#}'` .
 
 #### How to specify in how many lines to search for the license header in each file
 
-You can add `--detect-license-in-X-top-lines=<X>` to search for license in top X lines (default 5)
+You can add `--detect-license-in-X-top-lines=<X>` to search for the license
+in top X lines (default 5).
 
 #### Removing old license and replacing it with a new one
-In case you want to remove the comment headers introduced by `insert-license` hook,
-e.g. because you want to change the wording of your `LICENSE.txt` and update the comments in your source files:
 
-1. temporarily add the `--remove-header` arg in your `.pre-commit-config.yaml`
-2. run the hook on all your files: `pre-commit run insert-license --all-files`
-3. remove the `--remove-header` arg and update your `LICENSE.txt`
-4. re-run the hook on all your files
+In case you want to remove the comment headers introduced by
+`insert-license` hook, e.g. because you want to change the wording of your
+`LICENSE.txt` and update the comments in your source files:
+
+1. Temporarily add the `--remove-header` arg in your
+   `.pre-commit-config.yaml` ;
+2. Run the hook on all your files:
+   `pre-commit run insert-license --all-files` ;
+3. Remove the `--remove-header` arg and update your `LICENSE.txt` ;
+4. Re-run the hook on all your files.
 
 #### Fuzzy license matching
 
-In some cases your license files can contain several slightly different variants of the license - either
-containing slight modifications or differently broken lines of the license text. By
-default the plugin does exact matching when searching for the license and in such case it will add second
-licence on top - leaving the non-perfectly matched one in the source code. You can prevent that and add
-`--fuzzy-match-generates-todo` flag in which case fuzzy matching is performed based on Levenshtein distance
-of set of tokens in expected and actual license text (partial match in two sets is used).
-The license is detected if the ratio is > than `--fuzzy-ratio-cut-off` parameter (default 85) - ration
-corresponds roughly to how well the expected and actual license match (scale 0 - 100).
-Additionally `--fuzzy-match-extra-lines-to-check` lines in this case are checked for the licence
-in case it has lines broken differently and takes more lines (default 3).
+In some cases your license files can contain several slightly different
+variants of the license - either containing slight modifications or
+differently broken lines of the license text. By default the plugin does
+exact matching when searching for the license and in such case it will add
+second licence on top - leaving the non-perfectly matched one in the source
+code. You can prevent that and add `--fuzzy-match-generates-todo` flag in
+which case fuzzy matching is performed based on Levenshtein distance of set
+of tokens in expected and actual license text (partial match in two sets is
+used). The license is detected if the ratio is > than
+`--fuzzy-ratio-cut-off` parameter (default 85) - ration corresponds roughly
+to how well the expected and actual license match (scale 0 - 100).
+Additionally `--fuzzy-match-extra-lines-to-check` lines in this case are
+checked for the licence in case it has lines broken differently and takes
+more lines (default 3).
 
-If a fuzzy match is found (and no exact match), a TODO comment
-is inserted at the beginning of the match found. The comment inserted can be overridden by
-`--fuzzy-match-todo-comment=<COMMENT>` flag. By default it is
+If a fuzzy match is found (and no exact match), a TODO comment is inserted
+at the beginning of the match found. The comment inserted can be overridden
+by `--fuzzy-match-todo-comment=<COMMENT>` flag. By default it is
 `TODO: This license is not consistent with license used in the project`
-Additionally instructions on what to do are inserted in this case. By default instructions are:
+Additionally instructions on what to do are inserted in this case. By
+default instructions are:
 `Delete the inconsistent license and above line and rerun pre-commit to insert a good license.`.
-You can change it via `--fuzzy-match-todo-instructions` argument of the hook.
+You can change it via `--fuzzy-match-todo-instructions` argument of the
+hook.
 
-When the TODO comment is committed, pre-commit will fail with appropriate message. The check will fails
-systematically if the `--fuzzy-match-generates-todo` flag is set or not. You will need to remove the TODO comment
-and licence so that it gets re-added in order to get rid of the error.
+When the TODO comment is committed, pre-commit will fail with appropriate
+message. The check will fails systematically if the
+`--fuzzy-match-generates-todo` flag is set or not. You will need to remove
+the TODO comment and licence so that it gets re-added in order to get rid
+of the error.
 
 License insertion can be skipped altogether if the file contains the
-'SKIP LICENSE INSERTION' in the first X top lines. This can also be overridden by
-`--skip-license-insertion-comment=<COMMENT>` flag.
-
+`SKIP LICENSE INSERTION` in the first X top lines. This can also be
+overridden by `--skip-license-insertion-comment=<COMMENT>` flag.
 
 ## Handy shell functions
-```
+
+```shell
 pre_commit_all_cache_repos () {  # Requires sqlite3
     sqlite3 -header -column ~/.cache/pre-commit/db.db < <(echo -e ".width 50\nSELECT repo, ref, path FROM repos ORDER BY repo;")
 }
@@ -131,138 +152,161 @@ pre_commit_db_rm_repo () {  # Requires sqlite3
 
 ### Forbid / remove some unicode characters
 
-    -   repo: local
-        hooks:
-        -   id: forbid-unicode-non-breaking-spaces
-            name: Detect unicode non-breaking space character U+00A0 aka M-BM-
-            language: system
-            entry: perl -ne 'print if $m = /\xc2\xa0/; $t ||= $m; END{{exit $t}}'
-            files: ''
-        -   id: remove-unicode-non-breaking-spaces
-            name: Remove unicode non-breaking space character U+00A0 aka M-BM-
-            language: system
-            entry: perl -pi* -e 's/\xc2\xa0/ /g && ($t = 1) && print STDERR $_; END{{exit
-                $t}}'
-            files: ''
-        -   id: forbid-en-dashes
-            name: Detect the EXTREMELY confusing unicode character U+2013
-            language: system
-            entry: perl -ne 'print if $m = /\xe2\x80\x93/; $t ||= $m; END{{exit $t}}'
-            files: ''
-        -   id: remove-en-dashes
-            name: Remove the EXTREMELY confusing unicode character U+2013
-            language: system
-            entry: perl -pi* -e 's/\xe2\x80\x93/-/g && ($t = 1) && print STDERR $_; END{{exit
-                $t}}'
-            files: ''
+```yaml
+- repo: local
+  hooks:
+    - id: forbid-unicode-non-breaking-spaces
+      name: Detect unicode non-breaking space character U+00A0 aka M-BM-
+      language: system
+      entry: perl -ne 'print if $m = /\xc2\xa0/; $t ||= $m; END{{exit $t}}'
+      files: ''
+    - id: remove-unicode-non-breaking-spaces
+      name: Remove unicode non-breaking space character U+00A0 aka M-BM-
+      language: system
+      entry: perl -pi* -e 's/\xc2\xa0/ /g && ($t = 1) && print STDERR $_; END{{exit
+        $t}}'
+      files: ''
+    - id: forbid-en-dashes
+      name: Detect the EXTREMELY confusing unicode character U+2013
+      language: system
+      entry: perl -ne 'print if $m = /\xe2\x80\x93/; $t ||= $m; END{{exit $t}}'
+      files: ''
+    - id: remove-en-dashes
+      name: Remove the EXTREMELY confusing unicode character U+2013
+      language: system
+      entry: perl -pi* -e 's/\xe2\x80\x93/-/g && ($t = 1) && print STDERR $_; END{{exit
+        $t}}'
+      files: ''
+```
 
 ### Bash syntax validation
 
-    -   repo: local
-        hooks:
-        -   id: check-bash-syntax
-            name: Check Shell scripts syntax corectness
-            language: system
-            entry: bash -n
-            files: \.sh$
+```yaml
+- repo: local
+  hooks:
+  - id: check-bash-syntax
+    name: Check Shell scripts syntax correctness
+    language: system
+    entry: bash -n
+    files: \.sh$
+```
 
 ### For Groovy-like Jenkins pipelines
 
+```yaml
+- repo: local
+  hooks:
+  - id: forbid-abstract-classes-and-traits
+    name: Ensure neither abstract classes nor traits are used
+    language: pygrep
+    entry: "^(abstract|trait) "
+    files: ^src/.*\.groovy$
 ```
--   repo: local
-    hooks:
-    -   id: forbid-abstract-classes-and-traits
-        name: Ensure neither abstract classes nor traits are used
-        language: pygrep
-        entry: "^(abstract|trait) "
-        files: ^src/.*\.groovy$
-```
-**Rationale:** `abstract` classes & `traits` do not work in Jenkins pipelines : cf. https://issues.jenkins-ci.org/browse/JENKINS-39329 & https://issues.jenkins-ci.org/browse/JENKINS-46145
 
+**Rationale:** `abstract` classes & `traits` do not work in Jenkins
+pipelines : cf. https://issues.jenkins-ci.org/browse/JENKINS-39329 &
+https://issues.jenkins-ci.org/browse/JENKINS-46145 .
+
+```yaml
+- repo: local
+  hooks:
+  - id: force-JsonSlurperClassic
+    name: Ensure JsonSlurperClassic is used instead of non-serializable JsonSlurper
+    language: pygrep
+    entry: JsonSlurper[^C]
+    files: \.groovy$
 ```
--   repo: local
-    hooks:
-    -   id: force-JsonSlurperClassic
-        name: Ensure JsonSlurperClassic is used instead of non-serializable JsonSlurper
-        language: pygrep
-        entry: JsonSlurper[^C]
-        files: \.groovy$
-```
+
 **Rationale:** cf. http://stackoverflow.com/a/38439681/636849
 
+```yaml
+- repo: local
+  hooks:
+    - id: Jenkinsfile-linter
+      name: Check Jenkinsfile following the scripted-pipeline syntax using Jenkins
+        API
+      files: Jenkinsfile
+      language: system
+      entry: sh -c '! curl --silent $JENKINS_URL/job/MyPipelineName/job/master/1/replay/checkScriptCompile
+        --user $JENKINS_USER:$JENKINS_TOKEN --data-urlencode value@Jenkinsfile |
+        grep -F "\"status\":\"fail\""'
 ```
--   repo: local
-    hooks:
-        -   id: Jenkinsfile-linter
-            name: Check Jenkinsfile following the scripted-pipeline syntax using Jenkins API
-            files: Jenkinsfile
-            language: system
-            entry: sh -c '! curl --silent $JENKINS_URL/job/MyPipelineName/job/master/1/replay/checkScriptCompile --user $JENKINS_USER:$JENKINS_TOKEN --data-urlencode value@Jenkinsfile | grep -F "\"status\":\"fail\""'
-```
-Note: the `$JENKINS_TOKEN` can be retrieved from `$JENKINS_URL/user/$USER_NAME/configure`
 
-Beware, in 1 case on 6 I faced this unsolved bug with explictely-loaded libraries: https://issues.jenkins-ci.org/browse/JENKINS-42730
+Note: the `$JENKINS_TOKEN` can be retrieved from
+`$JENKINS_URL/user/$USER_NAME/configure`
 
-Also, there is also a linter for the declarative syntax: https://jenkins.io/doc/book/pipeline/development/#linter
+Beware, in 1 case on 6 I faced this unsolved bug with explictly-loaded
+libraries: https://issues.jenkins-ci.org/browse/JENKINS-42730 .
+
+Also, there is also a linter for the declarative syntax:
+https://jenkins.io/doc/book/pipeline/development/#linter .
 
 ### Forbid some Javascript keywords for browser retrocompatibility issues
 
-    -   repo: local
-        hooks:
-        -   id: js-forbid-const
-            name: The const keyword is not supported by IE10
-            language: pygrep
-            entry: "const "
-            files: \.js$
-        -   id: js-forbid-let
-            name: The let keyword is not supported by IE10
-            language: pygrep
-            entry: "let "
-            files: \.js$
+```yaml
+- repo: local
+  hooks:
+    - id: js-forbid-const
+      name: The const keyword is not supported by IE10
+      language: pygrep
+      entry: 'const '
+      files: \.js$
+    - id: js-forbid-let
+      name: The let keyword is not supported by IE10
+      language: pygrep
+      entry: 'let '
+      files: \.js$
+```
 
 ### CSS
 
-    -   repo: local
-        hooks:
-        -   id: css-forbid-px
-            name: In CSS files, use rem or % over px
-            language: pygrep
-            entry: px
-            files: \.css$
-        -   id: ot-sanitize-fonts
-            name: Calling ot-sanitise on otf/ttf/woff/woff2 font files
-            language: system
-            entry: sh -c 'type ot-sanitise >/dev/null && for font in "$@"; do echo "$font"; ot-sanitise "$font"; done || echo "WARNING Command ot-sanitise not found - skipping check"'
-            files: \.(otf|ttf|woff|woff2)$
+```yaml
+- repo: local
+  hooks:
+    - id: css-forbid-px
+      name: In CSS files, use rem or % over px
+      language: pygrep
+      entry: px
+      files: \.css$
+    - id: ot-sanitize-fonts
+      name: Calling ot-sanitise on otf/ttf/woff/woff2 font files
+      language: system
+      entry: sh -c 'type ot-sanitise >/dev/null && for font in "$@"; do echo "$font";
+        ot-sanitise "$font"; done || echo "WARNING Command ot-sanitise not found
+        - skipping check"'
+      files: \.(otf|ttf|woff|woff2)$
+```
 
 ### Some Angular 1.5 checks
 
-    -   repo: local
-        hooks:
-        -   id: angular-forbid-apply
-            name: In AngularJS, use $digest over $apply
-            language: pygrep
-            entry: \$apply
-            files: \.js$
-        -   id: angular-forbid-ngrepeat-without-trackby
-            name: In AngularJS, ALWAYS use 'track by' with ng-repeat
-            language: pygrep
-            entry: ng-repeat(?!.*track by)
-            files: \.html$
-        -   id: angular-forbid-ngmodel-with-no-dot
-            name: In AngularJS, "Whenever you have ng-model there's gotta be a dot in
-                there somewhere"
-            language: pygrep
-            entry: ng-model="?[^.]+[" ]
-            files: \.html$
-
+```yaml
+- repo: local
+  hooks:
+    - id: angular-forbid-apply
+      name: In AngularJS, use $digest over $apply
+      language: pygrep
+      entry: \$apply
+      files: \.js$
+    - id: angular-forbid-ngrepeat-without-trackby
+      name: In AngularJS, ALWAYS use 'track by' with ng-repeat
+      language: pygrep
+      entry: ng-repeat(?!.*track by)
+      files: \.html$
+    - id: angular-forbid-ngmodel-with-no-dot
+      name: In AngularJS, "Whenever you have ng-model there's gotta be a dot in
+        there somewhere"
+      language: pygrep
+      entry: ng-model="?[^.]+[" ]
+      files: \.html$
+```
 
 ## Development
 
-The [GitHub releases](https://github.com/Lucas-C/pre-commit-hooks/releases) form the historical ChangeLog.
+The [GitHub releases](https://github.com/Lucas-C/pre-commit-hooks/releases)
+form the historical ChangeLog.
 
 ### Releasing a new version
 
-1. edit version in `setup.py`, `README.md` & `.pre-commit-config.yaml`
-2. `git commit -nam "Version bump to $version" && git tag $version && git push && git push --tags`
-3. publish a GitHub release
+1. Edit version in `setup.py`, `README.md` & `.pre-commit-config.yaml`;
+2. `git commit -nam "Version bump to $version" && git tag $version && git push && git push --tags`;
+3. Publish a GitHub release.

--- a/README.md
+++ b/README.md
@@ -86,13 +86,16 @@ In case you want to remove the comment headers introduced by
 
 In some cases your license files can contain several slightly different
 variants of the license - either containing slight modifications or
-differently broken lines of the license text. By default the plugin does
+differently broken lines of the license text.\
+By default the plugin does
 exact matching when searching for the license and in such case it will add
 second licence on top - leaving the non-perfectly matched one in the source
-code. You can prevent that and add `--fuzzy-match-generates-todo` flag in
+code.\
+You can prevent that and add `--fuzzy-match-generates-todo` flag in
 which case fuzzy matching is performed based on Levenshtein distance of set
 of tokens in expected and actual license text (partial match in two sets is
-used). The license is detected if the ratio is > than
+used).\
+The license is detected if the ratio is > than
 `--fuzzy-ratio-cut-off` parameter (default 85) - ration corresponds roughly
 to how well the expected and actual license match (scale 0 - 100).
 Additionally `--fuzzy-match-extra-lines-to-check` lines in this case are
@@ -101,17 +104,22 @@ more lines (default 3).
 
 If a fuzzy match is found (and no exact match), a TODO comment is inserted
 at the beginning of the match found. The comment inserted can be overridden
-by `--fuzzy-match-todo-comment=<COMMENT>` flag. By default it is
+by `--fuzzy-match-todo-comment=<COMMENT>` flag.\
+By default the inserted
+comment is
 `TODO: This license is not consistent with license used in the project`
-Additionally instructions on what to do are inserted in this case. By
-default instructions are:
-`Delete the inconsistent license and above line and rerun pre-commit to insert a good license.`.
-You can change it via `--fuzzy-match-todo-instructions` argument of the
-hook.
+Additionally instructions on what to do are inserted in this case.\
+By
+default instructions
+are:\
+`Delete the inconsistent license and above line and rerun pre-commit to insert a good license.`.\
+You
+can change it via `--fuzzy-match-todo-instructions` argument of the hook.
 
 When the TODO comment is committed, pre-commit will fail with appropriate
 message. The check will fails systematically if the
-`--fuzzy-match-generates-todo` flag is set or not. You will need to remove
+`--fuzzy-match-generates-todo` flag is set or not.\
+You will need to remove
 the TODO comment and licence so that it gets re-added in order to get rid
 of the error.
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,5 @@ pre-commit
 pytest
 pytest-cov
 coverage
+fuzzywuzzy
+python-Levenshtein-wheels

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+from __future__ import print_function, annotations
+from typing import List
 import argparse
 import collections
 import sys
@@ -48,8 +49,8 @@ def main(argv=None):
 
     license_info = get_license_info(args)
 
-    changed_files = []
-    todo_files = []
+    changed_files: List[str] = []
+    todo_files: List[str] = []
 
     check_failed = process_files(args, changed_files, todo_files, license_info)
 
@@ -169,7 +170,9 @@ def _read_file_content(src_filepath):
         except UnicodeDecodeError as error:
             last_error = error
     print("Error while processing: {} - file encoding is probably not supported".format(src_filepath))
-    raise last_error
+    if last_error is not None:   # Avoid mypy message
+        raise last_error
+    raise RuntimeError("Unexpected branch taken (_read_file_content)")
 
 
 def license_not_found(remove_header, license_info, src_file_content, src_filepath):

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -8,9 +8,11 @@ import sys
 
 from fuzzywuzzy import fuzz
 
-FUZZY_MATCH_TODO_COMMENT = " TODO: This license is not consistent with license used in the project."
-FUZZY_MATCH_TODO_INSTRUCTIONS = \
-    "       Delete the inconsistent license and above line and rerun pre-commit to insert a good license."
+FUZZY_MATCH_TODO_COMMENT = (" TODO: This license is not consistent with"
+                            " license used in the project.")
+FUZZY_MATCH_TODO_INSTRUCTIONS = (
+    "       Delete the inconsistent license and above line"
+    " and rerun pre-commit to insert a good license." )
 FUZZY_MATCH_EXTRA_LINES_TO_CHECK = 3
 
 SKIP_LICENSE_INSERTION_COMMENT = "SKIP LICENSE INSERTION"
@@ -36,6 +38,8 @@ def main(argv=None):
                         help='Can be a single prefix or a triplet: '
                              '<comment-start>|<comment-prefix>|<comment-end>'
                              'E.g.: /*| *| */')
+    parser.add_argument('--no-space', action='store_true',
+                        help='Do not add extra space beyond the comment-style spec')
     parser.add_argument('--detect-license-in-X-top-lines', type=int, default=5)
     parser.add_argument('--fuzzy-match-generates-todo', action='store_true')
     parser.add_argument('--fuzzy-ratio-cut-off', type=int, default=85)
@@ -70,11 +74,12 @@ def main(argv=None):
 def get_license_info(args):
     comment_start, comment_end = None, None
     comment_prefix = args.comment_style.replace('\\t', '\t')
+    extra_space = ' ' if not args.no_space and comment_prefix != '' else ''
     if '|' in comment_prefix:
         comment_start, comment_prefix, comment_end = comment_prefix.split('|')
     with open(args.license_filepath, encoding='utf8') as license_file:
         plain_license = license_file.readlines()
-    prefixed_license = ['{}{}{}'.format(comment_prefix, ' ' if line.strip() else '', line)
+    prefixed_license = ['{}{}{}'.format(comment_prefix, extra_space if line.strip() else '', line)
                         for line in plain_license]
     eol = '\r\n' if prefixed_license[0][-2:] == '\r\n' else '\n'
 

--- a/tests/insert_license_test.py
+++ b/tests/insert_license_test.py
@@ -13,39 +13,41 @@ from pre_commit_hooks.insert_license import find_license_header_index
 
 
 @pytest.mark.parametrize(
-    ('license_file_path', 'src_file_path', 'comment_prefix', 'new_src_file_expected', 'fail_check'),
+    ('license_file_path', 'src_file_path', 'comment_prefix', 'new_src_file_expected', 'fail_check', 'extra_args'),
     map(lambda a: a[:1] + a[1], product(  # combine license files with other args
         ('LICENSE_with_trailing_newline.txt', 'LICENSE_without_trailing_newline.txt'),
         (
-            ('module_without_license.py', '#', 'module_with_license.py', True),
-            ('module_without_license_skip.py', '#', None, False),
-            ('module_with_license.py', '#', None, False),
-            ('module_with_license_todo.py', '#', None, True),
+            ('module_without_license.py', '#', 'module_with_license.py', True, None),
+            ('module_without_license_skip.py', '#', None, False, None),
+            ('module_with_license.py', '#', None, False, None),
+            ('module_with_license_todo.py', '#', None, True, None),
 
-            ('module_without_license.jinja', '{#||#}', 'module_with_license.jinja', True),
-            ('module_without_license_skip.jinja', '{#||#}', None, False),
-            ('module_with_license.jinja', '{#||#}', None, False),
-            ('module_with_license_todo.jinja', '{#||#}', None, True),
+            ('module_without_license.jinja', '{#||#}', 'module_with_license.jinja', True, None),
+            ('module_without_license_skip.jinja', '{#||#}', None, False, None),
+            ('module_with_license.jinja', '{#||#}', None, False, None),
+            ('module_with_license_todo.jinja', '{#||#}', None, True, None),
 
-            ('module_without_license_and_shebang.py', '#', 'module_with_license_and_shebang.py', True),
-            ('module_without_license_and_shebang_skip.py', '#', None, False),
-            ('module_with_license_and_shebang.py', '#', None, False),
-            ('module_with_license_and_shebang_todo.py', '#', None, True),
+            ('module_without_license_and_shebang.py', '#', 'module_with_license_and_shebang.py', True, None),
+            ('module_without_license_and_shebang_skip.py', '#', None, False, None),
+            ('module_with_license_and_shebang.py', '#', None, False, None),
+            ('module_with_license_and_shebang_todo.py', '#', None, True, None),
 
-            ('module_without_license.groovy', '//', 'module_with_license.groovy', True),
-            ('module_without_license_skip.groovy', '//', None, False),
-            ('module_with_license.groovy', '//', None, False),
-            ('module_with_license_todo.groovy', '//', None, True),
+            ('module_without_license.groovy', '//', 'module_with_license.groovy', True, None),
+            ('module_without_license_skip.groovy', '//', None, False, None),
+            ('module_with_license.groovy', '//', None, False, None),
+            ('module_with_license_todo.groovy', '//', None, True, None),
 
-            ('module_without_license.css', '/*| *| */', 'module_with_license.css', True),
+            ('module_without_license.css', '/*| *| */', 'module_with_license.css', True, None),
             ('module_without_license_and_few_words.css', '/*| *| */',
-                'module_with_license_and_few_words.css', True),  # Test fuzzy match does not match greedily
-            ('module_without_license_skip.css', '/*| *| */', None, False),
-            ('module_with_license.css', '/*| *| */', None, False),
-            ('module_with_license_todo.css', '/*| *| */', None, True),
+                'module_with_license_and_few_words.css', True, None),  # Test fuzzy match does not match greedily
+            ('module_without_license_skip.css', '/*| *| */', None, False, None),
+            ('module_with_license.css', '/*| *| */', None, False, None),
+            ('module_with_license_todo.css', '/*| *| */', None, True, None),
 
-            ('main_without_license.cpp', '/*|\t| */', 'main_with_license.cpp', True),
-            ('main_iso8859_without_license.cpp', '/*|\t| */', 'main_iso8859_with_license.cpp', True),
+            ('main_without_license.cpp', '/*|\t| */', 'main_with_license.cpp', True, None),
+            ('main_iso8859_without_license.cpp', '/*|\t| */', 'main_iso8859_with_license.cpp', True, None),
+            ('module_without_license.txt', '', 'module_with_license_noprefix.txt', True, None),
+            ('module_without_license.py', '#', 'module_with_license_nospace.py', True, ['--no-space']),
         ),
     )),
 )
@@ -54,11 +56,14 @@ def test_insert_license(license_file_path,
                         comment_prefix,
                         new_src_file_expected,
                         fail_check,
+                        extra_args,
                         tmpdir):
     with chdir_to_test_resources():
         path = tmpdir.join('src_file_path')
         shutil.copy(src_file_path, path.strpath)
         args = ['--license-filepath', license_file_path, '--comment-style', comment_prefix, path.strpath]
+        if extra_args is not None:
+            args.extend(extra_args)
         assert insert_license(args) == (1 if fail_check else 0)
         if new_src_file_expected:
             with open(new_src_file_expected) as expected_content_file:

--- a/tests/resources/module_with_license_noprefix.txt
+++ b/tests/resources/module_with_license_noprefix.txt
@@ -1,0 +1,6 @@
+Copyright (C) 2017 Teela O'Malley
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+import sys
+sys.stdout.write("FOO")

--- a/tests/resources/module_with_license_nospace.py
+++ b/tests/resources/module_with_license_nospace.py
@@ -1,0 +1,6 @@
+#Copyright (C) 2017 Teela O'Malley
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+
+import sys
+sys.stdout.write("FOO")

--- a/tests/resources/module_without_license.txt
+++ b/tests/resources/module_without_license.txt
@@ -1,0 +1,2 @@
+import sys
+sys.stdout.write("FOO")


### PR DESCRIPTION
Implements #29  .
Also adds two test cases for checking the updated behavior for `--comment-style ''` and the new option `--no-space`.

The documentation is not updated yet, waiting for validation of the code.