### PR TITLE
Add --insert-license-after-regex option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.idea/
 **/.coverage
 /venv/
+**/*.swp

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
           - --rcfile=.pylintrc
           - --reports=no
           - --py-version=3.7
+        additional_dependencies: [pytest, fuzzywuzzy]
         exclude: ^tests/resources/.*(init_with_license\.py|todo).*$
   - repo: https://github.com/psf/black
     rev: 22.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,13 @@ repos:
       - id: check-merge-conflict
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.32.1
+    hooks:
+      - id: pyupgrade
+        args:
+          - --py37-plus
+        exclude: ^tests/resources/.*
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v3.0.0a5
     hooks:
@@ -39,6 +46,7 @@ repos:
         args:
           - --rcfile=.pylintrc
           - --reports=no
+          - --py-version=3.7
         exclude: ^tests/resources/.*(init_with_license\.py|todo).*$
   - repo: https://github.com/psf/black
     rev: 22.6.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: remove-tabs
         exclude: tests/resources/main.*_with_license.cpp
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
         files: ''
@@ -33,7 +33,7 @@ repos:
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
   - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v3.0.0a4
+    rev: v3.0.0a5
     hooks:
       - id: pylint
         args:
@@ -41,7 +41,7 @@ repos:
           - --reports=no
         exclude: ^tests/resources/.*(init_with_license\.py|todo).*$
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
       - id: black
         stages: [manual]   # Skip in automated run for now
@@ -55,7 +55,7 @@ repos:
       - id: python-bandit-vulnerability-check
         args: [--skip, 'B101', --recursive, .]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.942
+    rev: v0.961
     hooks:
       - id: mypy
         args:

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-disable = duplicate-code, import-error, missing-docstring, multiple-imports
+disable = duplicate-code, missing-docstring, multiple-imports
 
 [FORMAT]
 max-line-length = 150

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-disable = bad-continuation, duplicate-code, import-error, missing-docstring, multiple-imports
+disable = duplicate-code, import-error, missing-docstring, multiple-imports
 
 [FORMAT]
 max-line-length = 150

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ variants of the license - either containing slight modifications or
 differently broken lines of the license text.\
 By default the plugin does
 exact matching when searching for the license and in such case it will add
-second licence on top - leaving the non-perfectly matched one in the source
+second license on top - leaving the non-perfectly matched one in the source
 code.\
 You can prevent that and add `--fuzzy-match-generates-todo` flag in
 which case fuzzy matching is performed based on Levenshtein distance of set
@@ -101,7 +101,7 @@ The license is detected if the ratio is > than
 `--fuzzy-ratio-cut-off` parameter (default 85) - ration corresponds roughly
 to how well the expected and actual license match (scale 0 - 100).
 Additionally `--fuzzy-match-extra-lines-to-check` lines in this case are
-checked for the licence in case it has lines broken differently and takes
+checked for the license in case it has lines broken differently and takes
 more lines (default 3).
 
 If a fuzzy match is found (and no exact match), a TODO comment is inserted
@@ -122,7 +122,7 @@ When the TODO comment is committed, pre-commit will fail with appropriate
 message. The check will fails systematically if the
 `--fuzzy-match-generates-todo` flag is set or not.\
 You will need to remove
-the TODO comment and licence so that it gets re-added in order to get rid
+the TODO comment and license so that it gets re-added in order to get rid
 of the error.
 
 License insertion can be skipped altogether if the file contains the

--- a/pre_commit_hooks/forbid_crlf.py
+++ b/pre_commit_hooks/forbid_crlf.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import argparse, sys
 from .utils import is_textfile
 

--- a/pre_commit_hooks/forbid_crlf.py
+++ b/pre_commit_hooks/forbid_crlf.py
@@ -17,7 +17,7 @@ def main(argv=None):
     files_with_crlf = [f for f in text_files if contains_crlf(f)]
     return_code = 0
     for file_with_crlf in files_with_crlf:
-        print('CRLF end-lines detected in file: {0}'.format(file_with_crlf))
+        print(f'CRLF end-lines detected in file: {file_with_crlf}')
         return_code = 1
     return return_code
 

--- a/pre_commit_hooks/forbid_crlf.py
+++ b/pre_commit_hooks/forbid_crlf.py
@@ -22,4 +22,4 @@ def main(argv=None):
     return return_code
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))  # pragma: no cover

--- a/pre_commit_hooks/forbid_tabs.py
+++ b/pre_commit_hooks/forbid_tabs.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import argparse, sys
 from .utils import is_textfile
 

--- a/pre_commit_hooks/forbid_tabs.py
+++ b/pre_commit_hooks/forbid_tabs.py
@@ -14,7 +14,7 @@ def main(argv=None):
     files_with_tabs = [f for f in text_files if contains_tabs(f)]
     return_code = 0
     for file_with_tabs in files_with_tabs:
-        print('Tabs detected in file: {0}'.format(file_with_tabs))
+        print(f'Tabs detected in file: {file_with_tabs}')
         return_code = 1
     return return_code
 

--- a/pre_commit_hooks/forbid_tabs.py
+++ b/pre_commit_hooks/forbid_tabs.py
@@ -19,4 +19,4 @@ def main(argv=None):
     return return_code
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))  # pragma: no cover

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function, annotations
-from typing import List
+from __future__ import annotations
 import argparse
 import collections
 import sys
@@ -53,8 +52,8 @@ def main(argv=None):
 
     license_info = get_license_info(args)
 
-    changed_files: List[str] = []
-    todo_files: List[str] = []
+    changed_files: list[str] = []
+    todo_files: list[str] = []
 
     check_failed = process_files(args, changed_files, todo_files, license_info)
 

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -187,7 +187,14 @@ def _read_file_content(src_filepath):
     raise RuntimeError("Unexpected branch taken (_read_file_content)")
 
 
-def license_not_found(remove_header: bool, license_info: LicenseInfo, src_file_content: List[str], src_filepath: str, encoding: str, after_regex: str) -> bool:
+def license_not_found(  # pylint: disable=too-many-arguments
+    remove_header: bool,
+    license_info: LicenseInfo,
+    src_file_content: list[str],
+    src_filepath: str,
+    encoding: str,
+    after_regex: str,
+) -> bool:
     """
     Executed when license is not found.
     It either adds license if remove_header is False,

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import argparse
 import collections
+import re
 import sys
 
 from fuzzywuzzy import fuzz
@@ -47,6 +48,8 @@ def main(argv=None):
     parser.add_argument('--fuzzy-match-extra-lines-to-check', type=int,
                         default=FUZZY_MATCH_EXTRA_LINES_TO_CHECK)
     parser.add_argument('--skip-license-insertion-comment', default=SKIP_LICENSE_INSERTION_COMMENT)
+    parser.add_argument('--insert-license-after-regex', default="",
+                        help="Insert license after line matching regex (ex: '^<\\?php$'")
     parser.add_argument('--remove-header', action='store_true')
     args = parser.parse_args(argv)
 
@@ -70,7 +73,7 @@ def main(argv=None):
     return 0
 
 
-def get_license_info(args):
+def get_license_info(args) -> LicenseInfo:
     comment_start, comment_end = None, None
     comment_prefix = args.comment_style.replace('\\t', '\t')
     extra_space = ' ' if not args.no_space_in_comment_prefix and comment_prefix != '' else ''
@@ -105,7 +108,7 @@ def get_license_info(args):
     return license_info
 
 
-def process_files(args, changed_files, todo_files, license_info):
+def process_files(args, changed_files, todo_files, license_info: LicenseInfo):
     """
     Processes all license files
     :param args: arguments of the hook
@@ -114,6 +117,7 @@ def process_files(args, changed_files, todo_files, license_info):
     :param license_info: license info named tuple
     :return: True if some files were changed or t.o.d.o is detected
     """
+    after_regex = args.insert_license_after_regex
     for src_filepath in args.filenames:
         src_file_content, encoding = _read_file_content(src_filepath)
         if skip_license_insert_found(
@@ -163,7 +167,8 @@ def process_files(args, changed_files, todo_files, license_info):
                                      license_info=license_info,
                                      src_file_content=src_file_content,
                                      src_filepath=src_filepath,
-                                     encoding=encoding):
+                                     encoding=encoding,
+                                     after_regex=after_regex):
                     changed_files.append(src_filepath)
     return changed_files or todo_files
 
@@ -182,9 +187,10 @@ def _read_file_content(src_filepath):
     raise RuntimeError("Unexpected branch taken (_read_file_content)")
 
 
-def license_not_found(remove_header, license_info, src_file_content, src_filepath, encoding):
+def license_not_found(remove_header: bool, license_info: LicenseInfo, src_file_content: List[str], src_filepath: str, encoding: str, after_regex: str) -> bool:
     """
-    Executed when license is not found. It either adds license if remove_header is False,
+    Executed when license is not found.
+    It either adds license if remove_header is False,
         does nothing if remove_header is True.
     :param remove_header: whether header should be removed if found
     :param license_info: license info named tuple
@@ -196,9 +202,15 @@ def license_not_found(remove_header, license_info, src_file_content, src_filepat
         index = 0
         for line in src_file_content:
             stripped_line = line.strip()
-            # Special treatment for shebang, encoding and empty lines when at the beginning of the file
+            # Special treatment for user provided regex,
+            # or shebang, file encoding directive,
+            # and empty lines when at the beginning of the file.
             # (adds license only after those)
-            if stripped_line.startswith("#!") \
+            if after_regex is not None and after_regex != "":
+                if re.match(after_regex, stripped_line):
+                    index += 1  # Skip matched line
+                    break       # And insert after that line.
+            elif stripped_line.startswith("#!") \
                     or stripped_line.startswith("# -*- coding") \
                     or stripped_line == "":
                 index += 1

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -49,7 +49,7 @@ def main(argv=None):
                         default=FUZZY_MATCH_EXTRA_LINES_TO_CHECK)
     parser.add_argument('--skip-license-insertion-comment', default=SKIP_LICENSE_INSERTION_COMMENT)
     parser.add_argument('--insert-license-after-regex', default="",
-                        help="Insert license after line matching regex (ex: '^<\\?php$'")
+                        help="Insert license after line matching regex (ex: '^<\\?php$')")
     parser.add_argument('--remove-header', action='store_true')
     args = parser.parse_args(argv)
 

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -307,12 +307,6 @@ def fail_license_todo_found(
     return False
 
 
-def remove_prefix(text, prefix):
-    if text.startswith(prefix):
-        return text[len(prefix):]
-    return text
-
-
 def fuzzy_find_license_header_index(src_file_content,  # pylint: disable=too-many-locals
                                     license_info,
                                     top_lines_count,
@@ -336,7 +330,7 @@ def fuzzy_find_license_header_index(src_file_content,  # pylint: disable=too-man
         ratio = fuzz.token_set_ratio(license_string, license_string_candidate)
         num_tokens = len(license_string_candidate.split(" "))
         num_tokens_diff = abs(num_tokens - expected_num_tokens)
-        if DEBUG_LEVENSHTEIN_DISTANCE_CALCULATION:
+        if DEBUG_LEVENSHTEIN_DISTANCE_CALCULATION:  # pragma: no cover
             print("License_string:{}".format(license_string))
             print("License_string_candidate:{}".format(license_string_candidate))
             print("Candidate offset:{}".format(candidate_offset))
@@ -349,10 +343,10 @@ def fuzzy_find_license_header_index(src_file_content,  # pylint: disable=too-man
                 best_ratio = ratio
                 best_line_number_match = i + candidate_offset
                 best_num_token_diff = num_tokens_diff
-                if DEBUG_LEVENSHTEIN_DISTANCE_CALCULATION:
+                if DEBUG_LEVENSHTEIN_DISTANCE_CALCULATION:  # pragma: no cover
                     print("Setting best line number match: {}, ratio {}, num tokens diff {}".format(
                         best_line_number_match, best_ratio, best_num_token_diff))
-        if DEBUG_LEVENSHTEIN_DISTANCE_CALCULATION:
+        if DEBUG_LEVENSHTEIN_DISTANCE_CALCULATION:  # pragma: no cover
             print("Best offset match {}".format(best_line_number_match))
     return best_line_number_match
 
@@ -398,4 +392,4 @@ def get_license_candidate_string(candidate_array, license_info):
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))  # pragma: no cover

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -359,10 +359,10 @@ def fuzzy_find_license_header_index(src_file_content,  # pylint: disable=too-man
 
 def get_license_candidate_string(candidate_array, license_info):
     """
-    Return licence candidate string from the array of strings retrieved
+    Return license candidate string from the array of strings retrieved
     :param candidate_array: array of lines of the candidate strings
-    :param license_info: LicenseInfo named tuple containing information about the licence
-    :return: Tuple of string version of the licence candidate and offset in lines where it starts.
+    :param license_info: LicenseInfo named tuple containing information about the license
+    :return: Tuple of string version of the license candidate and offset in lines where it starts.
     """
     license_string_candidate = ""
     stripped_comment_start = license_info.comment_start.strip() if license_info.comment_start else ""
@@ -370,23 +370,23 @@ def get_license_candidate_string(candidate_array, license_info):
     stripped_comment_end = license_info.comment_end.strip() if license_info.comment_end else ""
     in_license = False
     current_offset = 0
-    found_licence_offset = 0
+    found_license_offset = 0
     for license_line in candidate_array:
         stripped_line = license_line.strip()
         if not in_license:
             if stripped_comment_start:
                 if stripped_line.startswith(stripped_comment_start):
                     in_license = True
-                    found_licence_offset = current_offset + 1  # License starts in the next line
+                    found_license_offset = current_offset + 1  # License starts in the next line
                     continue
             else:
                 if stripped_comment_prefix:
                     if stripped_line.startswith(stripped_comment_prefix):
                         in_license = True
-                        found_licence_offset = current_offset  # License starts in this line
+                        found_license_offset = current_offset  # License starts in this line
                 else:
                     in_license = True
-                    found_licence_offset = current_offset  # We have no data :(. We start licence immediately
+                    found_license_offset = current_offset  # We have no data :(. We start license immediately
         else:
             if stripped_comment_end and stripped_line.startswith(stripped_comment_end):
                 break
@@ -394,7 +394,7 @@ def get_license_candidate_string(candidate_array, license_info):
                            stripped_line.startswith(stripped_comment_prefix)):
             license_string_candidate += stripped_line[len(stripped_comment_prefix):] + " "
         current_offset += 1
-    return license_string_candidate.strip(), found_licence_offset
+    return license_string_candidate.strip(), found_license_offset
 
 
 if __name__ == '__main__':

--- a/pre_commit_hooks/remove_crlf.py
+++ b/pre_commit_hooks/remove_crlf.py
@@ -34,4 +34,4 @@ def main(argv=None):
     return 0
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))  # pragma: no cover

--- a/pre_commit_hooks/remove_crlf.py
+++ b/pre_commit_hooks/remove_crlf.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import argparse, sys
 from .utils import is_textfile
 

--- a/pre_commit_hooks/remove_crlf.py
+++ b/pre_commit_hooks/remove_crlf.py
@@ -24,7 +24,7 @@ def main(argv=None):
     text_files = [f for f in args.filenames if is_textfile(f)]
     files_with_crlf = [f for f in text_files if contains_crlf(f)]
     for file_with_crlf in files_with_crlf:
-        print('Removing CRLF end-lines in: {0}'.format(file_with_crlf))
+        print(f'Removing CRLF end-lines in: {file_with_crlf}')
         removes_crlf_in_file(file_with_crlf)
     if files_with_crlf:
         print('')

--- a/pre_commit_hooks/remove_tabs.py
+++ b/pre_commit_hooks/remove_tabs.py
@@ -34,4 +34,4 @@ def main(argv=None):
     return 0
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))  # pragma: no cover

--- a/pre_commit_hooks/remove_tabs.py
+++ b/pre_commit_hooks/remove_tabs.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import argparse, sys
 from .utils import is_textfile
 

--- a/pre_commit_hooks/remove_tabs.py
+++ b/pre_commit_hooks/remove_tabs.py
@@ -23,8 +23,7 @@ def main(argv=None):
     text_files = [f for f in args.filenames if is_textfile(f)]
     files_with_tabs = [f for f in text_files if contains_tabs(f)]
     for file_with_tabs in files_with_tabs:
-        print('Substituting tabs in: {0} by {1} whitespaces'.format(
-                file_with_tabs, args.whitespaces_count))
+        print(f'Substituting tabs in: {file_with_tabs} by {args.whitespaces_count} whitespaces')
         removes_tabs_in_file(file_with_tabs, args.whitespaces_count)
     if files_with_tabs:
         print('')

--- a/tests/insert_license_test.py
+++ b/tests/insert_license_test.py
@@ -46,6 +46,7 @@ from pre_commit_hooks.insert_license import find_license_header_index
             ('main_iso8859_without_license.cpp', '/*|\t| */', 'main_iso8859_with_license.cpp', True, None),
             ('module_without_license.txt', '', 'module_with_license_noprefix.txt', True, None),
             ('module_without_license.py', '#', 'module_with_license_nospace.py', True, ['--no-space-in-comment-prefix']),
+            ('module_without_license.php', '/*| *| */', 'module_with_license.php', True, ['--insert-license-after-regex', '^<\\?php$']),
         ),
     )),
 )
@@ -201,7 +202,8 @@ def test_remove_license(license_file_path,
 def chdir_to_test_resources():
     prev_dir = os.getcwd()
     try:
-        os.chdir('tests/resources')
+        res_dir = os.path.dirname(os.path.realpath(__file__)) +'/resources'
+        os.chdir(res_dir)
         yield
     finally:
         os.chdir(prev_dir)

--- a/tests/insert_license_test.py
+++ b/tests/insert_license_test.py
@@ -58,6 +58,7 @@ def test_insert_license(license_file_path,
                         fail_check,
                         extra_args,
                         tmpdir):
+    encoding = 'ISO-8859-1' if 'iso8859' in src_file_path else 'utf-8'
     with chdir_to_test_resources():
         path = tmpdir.join('src_file_path')
         shutil.copy(src_file_path, path.strpath)
@@ -66,9 +67,9 @@ def test_insert_license(license_file_path,
             args.extend(extra_args)
         assert insert_license(args) == (1 if fail_check else 0)
         if new_src_file_expected:
-            with open(new_src_file_expected) as expected_content_file:
+            with open(new_src_file_expected, encoding=encoding) as expected_content_file:
                 expected_content = expected_content_file.read()
-            new_file_content = path.open().read()
+            new_file_content = path.open(encoding=encoding).read()
             assert new_file_content == expected_content
 
 
@@ -119,9 +120,9 @@ def test_fuzzy_match_license(license_file_path,
                 path.strpath]
         assert insert_license(args) == (1 if fail_check else 0)
         if new_src_file_expected:
-            with open(new_src_file_expected) as expected_content_file:
+            with open(new_src_file_expected, encoding='utf-8') as expected_content_file:
                 expected_content = expected_content_file.read()
-            new_file_content = path.open().read()
+            new_file_content = path.open(encoding='utf-8').read()
             assert new_file_content == expected_content
 
 
@@ -192,9 +193,9 @@ def test_remove_license(license_file_path,
             argv = ['--fuzzy-match-generates-todo'] + argv
         assert insert_license(argv) == (1 if fail_check else 0)
         if new_src_file_expected:
-            with open(new_src_file_expected) as expected_content_file:
+            with open(new_src_file_expected, encoding='utf-8') as expected_content_file:
                 expected_content = expected_content_file.read()
-            new_file_content = path.open().read()
+            new_file_content = path.open(encoding='utf-8').read()
             assert new_file_content == expected_content
 
 

--- a/tests/insert_license_test.py
+++ b/tests/insert_license_test.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from contextlib import contextmanager
 from itertools import product
 import os

--- a/tests/remove_crlf_test.py
+++ b/tests/remove_crlf_test.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
 from pathlib import Path
 
 import pytest

--- a/tests/remove_crlf_test.py
+++ b/tests/remove_crlf_test.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
+from pathlib import Path
 
 import pytest
 
@@ -14,16 +15,10 @@ from pre_commit_hooks.remove_crlf import main as remove_crlf
     ),
 )
 def test_remove_crlf(input_s, expected, tmpdir):
-    path = tmpdir.join('file.txt')
-    input_b = bytes(input_s, 'UTF-8')
-    expected_b = bytes(expected, 'UTF-8')
-    with open(path, 'wb') as test_file:
-        test_file.write(input_b)
-    with open(path, 'rb') as test_file:
-        assert test_file.read() == input_b
-    assert remove_crlf([path.strpath]) == 1
-    with open(path, 'rb') as test_file:
-        assert test_file.read() == expected_b
+    input_file = Path(tmpdir.join('file.txt'))
+    input_file.write_bytes(bytes(input_s, 'UTF-8'))
+    assert remove_crlf([str(input_file)]) == 1
+    assert input_file.read_bytes() == bytes(expected, 'UTF-8')
 
 
 @pytest.mark.parametrize(
@@ -34,16 +29,10 @@ def test_remove_crlf(input_s, expected, tmpdir):
     ),
 )
 def test_noremove_crlf(input_s, expected, tmpdir):
-    path = tmpdir.join('file.pdf')
-    input_b = bytes(input_s, 'UTF-8')
-    expected_b = bytes(expected, 'UTF-8')
-    with open(path, 'wb') as test_file:
-        test_file.write(input_b)
-    with open(path, 'rb') as test_file:
-        assert test_file.read() == input_b
-    assert remove_crlf([path.strpath]) == 0
-    with open(path, 'rb') as test_file:
-        assert test_file.read() == expected_b
+    input_file = Path(tmpdir.join('file.pdf'))
+    input_file.write_bytes(bytes(input_s, 'UTF-8'))
+    assert remove_crlf([str(input_file)]) == 0
+    assert input_file.read_bytes() == bytes(expected, 'UTF-8')
 
 
 @pytest.mark.parametrize(('arg'), ('', 'a.b', 'a/b'))

--- a/tests/remove_crlf_test.py
+++ b/tests/remove_crlf_test.py
@@ -15,9 +15,35 @@ from pre_commit_hooks.remove_crlf import main as remove_crlf
 )
 def test_remove_crlf(input_s, expected, tmpdir):
     path = tmpdir.join('file.txt')
-    path.write(input_s)
+    input_b = bytes(input_s, 'UTF-8')
+    expected_b = bytes(expected, 'UTF-8')
+    with open(path, 'wb') as test_file:
+        test_file.write(input_b)
+    with open(path, 'rb') as test_file:
+        assert test_file.read() == input_b
     assert remove_crlf([path.strpath]) == 1
-    assert path.read() == expected
+    with open(path, 'rb') as test_file:
+        assert test_file.read() == expected_b
+
+
+@pytest.mark.parametrize(
+    ('input_s', 'expected'),
+    (
+        ('foo\r\nbar', 'foo\r\nbar'),
+        ('bar\nbaz\r\n', 'bar\nbaz\r\n'),
+    ),
+)
+def test_noremove_crlf(input_s, expected, tmpdir):
+    path = tmpdir.join('file.pdf')
+    input_b = bytes(input_s, 'UTF-8')
+    expected_b = bytes(expected, 'UTF-8')
+    with open(path, 'wb') as test_file:
+        test_file.write(input_b)
+    with open(path, 'rb') as test_file:
+        assert test_file.read() == input_b
+    assert remove_crlf([path.strpath]) == 0
+    with open(path, 'rb') as test_file:
+        assert test_file.read() == expected_b
 
 
 @pytest.mark.parametrize(('arg'), ('', 'a.b', 'a/b'))

--- a/tests/remove_tabs_test.py
+++ b/tests/remove_tabs_test.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import pytest
 
 from pre_commit_hooks.remove_tabs import main as remove_tabs

--- a/tests/resources/main_iso8859_with_license.cpp
+++ b/tests/resources/main_iso8859_with_license.cpp
@@ -4,7 +4,7 @@
 	 Licensed under the Apache License, Version 2.0 (the "License");
  */
 
-// ISO-8859 character : Ã¦
+// ISO-8859 character : æ
 int main(int argc, char *argv[])
 {
     return 0;

--- a/tests/resources/module_with_license.php
+++ b/tests/resources/module_with_license.php
@@ -1,0 +1,8 @@
+<?php
+/*
+ * Copyright (C) 2017 Teela O'Malley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+print "Hello";

--- a/tests/resources/module_without_license.php
+++ b/tests/resources/module_without_license.php
@@ -1,0 +1,2 @@
+<?php
+print "Hello";

--- a/tests/text_utils_test.py
+++ b/tests/text_utils_test.py
@@ -11,6 +11,8 @@ from pre_commit_hooks.utils import is_text
     (
         (b'foo \r\nbar', True),
         (b'<a>\xe9 \n</a>\n', False),
+        (b'foo \x00bar', False),  # NUL character is not considered text
+        (b'', True),              # Empty file is considered text
     ),
 )
 def test_is_text(input_s, expected):

--- a/tests/text_utils_test.py
+++ b/tests/text_utils_test.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-
 import pytest
 
 from pre_commit_hooks.utils import is_text


### PR DESCRIPTION
Allows to implement #38 .

`--insert-license-after-regex '^<\?php$'` will insert the licence after the first appearing '<?php' or at the end of the file.