### PR TITLE
Coverage and fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.idea/
 **/.coverage
 /venv/
+**/*.swp

--- a/pre_commit_hooks/forbid_crlf.py
+++ b/pre_commit_hooks/forbid_crlf.py
@@ -22,4 +22,4 @@ def main(argv=None):
     return return_code
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))  # pragma: no cover

--- a/pre_commit_hooks/forbid_tabs.py
+++ b/pre_commit_hooks/forbid_tabs.py
@@ -19,4 +19,4 @@ def main(argv=None):
     return return_code
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))  # pragma: no cover

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -307,12 +307,6 @@ def fail_license_todo_found(
     return False
 
 
-def remove_prefix(text, prefix):
-    if text.startswith(prefix):
-        return text[len(prefix):]
-    return text
-
-
 def fuzzy_find_license_header_index(src_file_content,  # pylint: disable=too-many-locals
                                     license_info,
                                     top_lines_count,
@@ -336,7 +330,7 @@ def fuzzy_find_license_header_index(src_file_content,  # pylint: disable=too-man
         ratio = fuzz.token_set_ratio(license_string, license_string_candidate)
         num_tokens = len(license_string_candidate.split(" "))
         num_tokens_diff = abs(num_tokens - expected_num_tokens)
-        if DEBUG_LEVENSHTEIN_DISTANCE_CALCULATION:
+        if DEBUG_LEVENSHTEIN_DISTANCE_CALCULATION:  # pragma: no cover
             print("License_string:{}".format(license_string))
             print("License_string_candidate:{}".format(license_string_candidate))
             print("Candidate offset:{}".format(candidate_offset))
@@ -349,10 +343,10 @@ def fuzzy_find_license_header_index(src_file_content,  # pylint: disable=too-man
                 best_ratio = ratio
                 best_line_number_match = i + candidate_offset
                 best_num_token_diff = num_tokens_diff
-                if DEBUG_LEVENSHTEIN_DISTANCE_CALCULATION:
+                if DEBUG_LEVENSHTEIN_DISTANCE_CALCULATION:  # pragma: no cover
                     print("Setting best line number match: {}, ratio {}, num tokens diff {}".format(
                         best_line_number_match, best_ratio, best_num_token_diff))
-        if DEBUG_LEVENSHTEIN_DISTANCE_CALCULATION:
+        if DEBUG_LEVENSHTEIN_DISTANCE_CALCULATION:  # pragma: no cover
             print("Best offset match {}".format(best_line_number_match))
     return best_line_number_match
 
@@ -398,4 +392,4 @@ def get_license_candidate_string(candidate_array, license_info):
 
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))  # pragma: no cover

--- a/pre_commit_hooks/remove_crlf.py
+++ b/pre_commit_hooks/remove_crlf.py
@@ -34,4 +34,4 @@ def main(argv=None):
     return 0
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))  # pragma: no cover

--- a/pre_commit_hooks/remove_tabs.py
+++ b/pre_commit_hooks/remove_tabs.py
@@ -34,4 +34,4 @@ def main(argv=None):
     return 0
 
 if __name__ == '__main__':
-    sys.exit(main(sys.argv[1:]))
+    sys.exit(main(sys.argv[1:]))  # pragma: no cover

--- a/tests/remove_crlf_test.py
+++ b/tests/remove_crlf_test.py
@@ -15,9 +15,35 @@ from pre_commit_hooks.remove_crlf import main as remove_crlf
 )
 def test_remove_crlf(input_s, expected, tmpdir):
     path = tmpdir.join('file.txt')
-    path.write(input_s)
+    input_b = bytes(input_s, 'UTF-8')
+    expected_b = bytes(expected, 'UTF-8')
+    with open(path, 'wb') as test_file:
+        test_file.write(input_b)
+    with open(path, 'rb') as test_file:
+        assert test_file.read() == input_b
     assert remove_crlf([path.strpath]) == 1
-    assert path.read() == expected
+    with open(path, 'rb') as test_file:
+        assert test_file.read() == expected_b
+
+
+@pytest.mark.parametrize(
+    ('input_s', 'expected'),
+    (
+        ('foo\r\nbar', 'foo\r\nbar'),
+        ('bar\nbaz\r\n', 'bar\nbaz\r\n'),
+    ),
+)
+def test_noremove_crlf(input_s, expected, tmpdir):
+    path = tmpdir.join('file.pdf')
+    input_b = bytes(input_s, 'UTF-8')
+    expected_b = bytes(expected, 'UTF-8')
+    with open(path, 'wb') as test_file:
+        test_file.write(input_b)
+    with open(path, 'rb') as test_file:
+        assert test_file.read() == input_b
+    assert remove_crlf([path.strpath]) == 0
+    with open(path, 'rb') as test_file:
+        assert test_file.read() == expected_b
 
 
 @pytest.mark.parametrize(('arg'), ('', 'a.b', 'a/b'))

--- a/tests/text_utils_test.py
+++ b/tests/text_utils_test.py
@@ -11,6 +11,8 @@ from pre_commit_hooks.utils import is_text
     (
         (b'foo \r\nbar', True),
         (b'<a>\xe9 \n</a>\n', False),
+        (b'foo \x00bar', False),  # NUL character is not considered text
+        (b'', True),              # Empty file is considered text
     ),
 )
 def test_is_text(input_s, expected):


### PR DESCRIPTION
- Correct test in remove_crlf that was invalid (did not actually test removal).
- Add test to check that crlf is not removed on known binary files (to increase coverage).
- Add some pragmas to ignore lines for coverage.
- Ignore .swp files.

Note:
- Generating a test case for the the remaining uncovered lines in insert_license.py (after applying the branch removeUnreachableCode) is likely more efficient for the person that wrote the corresponding lines.  