### PR TITLE
Add --insert-license-after-regex option 

### DIFF
--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 import argparse
 import collections
+import re
 import sys
 
 from fuzzywuzzy import fuzz
@@ -47,6 +48,8 @@ def main(argv=None):
     parser.add_argument('--fuzzy-match-extra-lines-to-check', type=int,
                         default=FUZZY_MATCH_EXTRA_LINES_TO_CHECK)
     parser.add_argument('--skip-license-insertion-comment', default=SKIP_LICENSE_INSERTION_COMMENT)
+    parser.add_argument('--insert-license-after-regex', default="",
+                        help="Insert license after line matching regex (ex: '^<\\?php$'")
     parser.add_argument('--remove-header', action='store_true')
     args = parser.parse_args(argv)
 
@@ -70,7 +73,7 @@ def main(argv=None):
     return 0
 
 
-def get_license_info(args):
+def get_license_info(args) -> LicenseInfo:
     comment_start, comment_end = None, None
     comment_prefix = args.comment_style.replace('\\t', '\t')
     extra_space = ' ' if not args.no_space_in_comment_prefix and comment_prefix != '' else ''
@@ -105,7 +108,7 @@ def get_license_info(args):
     return license_info
 
 
-def process_files(args, changed_files, todo_files, license_info):
+def process_files(args, changed_files, todo_files, license_info: LicenseInfo):
     """
     Processes all license files
     :param args: arguments of the hook
@@ -114,6 +117,7 @@ def process_files(args, changed_files, todo_files, license_info):
     :param license_info: license info named tuple
     :return: True if some files were changed or t.o.d.o is detected
     """
+    after_regex = args.insert_license_after_regex
     for src_filepath in args.filenames:
         src_file_content, encoding = _read_file_content(src_filepath)
         if skip_license_insert_found(
@@ -163,7 +167,8 @@ def process_files(args, changed_files, todo_files, license_info):
                                      license_info=license_info,
                                      src_file_content=src_file_content,
                                      src_filepath=src_filepath,
-                                     encoding=encoding):
+                                     encoding=encoding,
+                                     after_regex=after_regex):
                     changed_files.append(src_filepath)
     return changed_files or todo_files
 
@@ -182,9 +187,10 @@ def _read_file_content(src_filepath):
     raise RuntimeError("Unexpected branch taken (_read_file_content)")
 
 
-def license_not_found(remove_header, license_info, src_file_content, src_filepath, encoding):
+def license_not_found(remove_header: bool, license_info: LicenseInfo, src_file_content: List[str], src_filepath: str, encoding: str, after_regex: str) -> bool:
     """
-    Executed when license is not found. It either adds license if remove_header is False,
+    Executed when license is not found.
+    It either adds license if remove_header is False,
         does nothing if remove_header is True.
     :param remove_header: whether header should be removed if found
     :param license_info: license info named tuple
@@ -196,9 +202,15 @@ def license_not_found(remove_header, license_info, src_file_content, src_filepat
         index = 0
         for line in src_file_content:
             stripped_line = line.strip()
-            # Special treatment for shebang, encoding and empty lines when at the beginning of the file
+            # Special treatment for user provided regex,
+            # or shebang, file encoding directive,
+            # and empty lines when at the beginning of the file.
             # (adds license only after those)
-            if stripped_line.startswith("#!") \
+            if after_regex is not None and after_regex != "":
+                if re.match(after_regex, stripped_line):
+                    index += 1  # Skip matched line
+                    break       # And insert after that line.
+            elif stripped_line.startswith("#!") \
                     or stripped_line.startswith("# -*- coding") \
                     or stripped_line == "":
                 index += 1

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -49,7 +49,7 @@ def main(argv=None):
                         default=FUZZY_MATCH_EXTRA_LINES_TO_CHECK)
     parser.add_argument('--skip-license-insertion-comment', default=SKIP_LICENSE_INSERTION_COMMENT)
     parser.add_argument('--insert-license-after-regex', default="",
-                        help="Insert license after line matching regex (ex: '^<\\?php$'")
+                        help="Insert license after line matching regex (ex: '^<\\?php$')")
     parser.add_argument('--remove-header', action='store_true')
     args = parser.parse_args(argv)
 

--- a/tests/insert_license_test.py
+++ b/tests/insert_license_test.py
@@ -46,6 +46,7 @@ from pre_commit_hooks.insert_license import find_license_header_index
             ('main_iso8859_without_license.cpp', '/*|\t| */', 'main_iso8859_with_license.cpp', True, None),
             ('module_without_license.txt', '', 'module_with_license_noprefix.txt', True, None),
             ('module_without_license.py', '#', 'module_with_license_nospace.py', True, ['--no-space-in-comment-prefix']),
+            ('module_without_license.php', '/*| *| */', 'module_with_license.php', True, ['--insert-license-after-regex', '^<\\?php$']),
         ),
     )),
 )
@@ -201,7 +202,8 @@ def test_remove_license(license_file_path,
 def chdir_to_test_resources():
     prev_dir = os.getcwd()
     try:
-        os.chdir('tests/resources')
+        res_dir = os.path.dirname(os.path.realpath(__file__)) +'/resources'
+        os.chdir(res_dir)
         yield
     finally:
         os.chdir(prev_dir)

--- a/tests/resources/module_with_license.php
+++ b/tests/resources/module_with_license.php
@@ -1,0 +1,8 @@
+<?php
+/*
+ * Copyright (C) 2017 Teela O'Malley
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ */
+
+print "Hello";

--- a/tests/resources/module_without_license.php
+++ b/tests/resources/module_without_license.php
@@ -1,0 +1,2 @@
+<?php
+print "Hello";


### PR DESCRIPTION
Replacement request for #40 .
Allows to implement https://github.com/Lucas-C/pre-commit-hooks/issues/38 .

--insert-license-after-regex '^<\?php$' will insert the licence after the first appearing '<?php' or at the end of the file.