### PR TITLE
ignore files by name or glob to remove_crlf

### DIFF
--- a/pre_commit_hooks/remove_crlf.py
+++ b/pre_commit_hooks/remove_crlf.py
@@ -1,5 +1,5 @@
 import argparse, sys
-from .utils import is_textfile
+from .utils import is_textfile, parse_argslist, parse_files
 
 def contains_crlf(filename):
     with open(filename, mode='rb') as file_checked:
@@ -19,8 +19,10 @@ def removes_crlf_in_file(filename):
 def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='filenames to check')
+    parser.add_argument('--ignore_files', default=set(), type=parse_argslist, help='files or globs to ignore')
     args = parser.parse_args(argv)
-    text_files = [f for f in args.filenames if is_textfile(f)]
+    ignores = parse_files(args.ignore_files)
+    text_files = [f for f in args.filenames if (f not in ignores) and (is_textfile(f))]
     files_with_crlf = [f for f in text_files if contains_crlf(f)]
     for file_with_crlf in files_with_crlf:
         print(f'Removing CRLF end-lines in: {file_with_crlf}')

--- a/pre_commit_hooks/utils.py
+++ b/pre_commit_hooks/utils.py
@@ -1,3 +1,6 @@
+import glob
+from collections.abc import Iterable
+
 # Taken from: http://code.activestate.com/recipes/173220-test-if-a-file-or-string-is-text-or-binary/
 
 KNOWN_BINARY_FILE_EXTS = ('.pdf',)
@@ -20,3 +23,16 @@ def is_text(stuff):
         return False
     else:
         return True
+
+def parse_argslist(value: str) :
+    return set(value.split(','))
+
+def flatten(nested):
+    if isinstance(nested, Iterable) and not isinstance(nested, str):
+        return sum(map(flatten, nested), [])
+
+    return [nested]
+
+def parse_files(files: Iterable):
+    _files = [glob.glob(f, recursive=True) for f in files]
+    return set(flatten(_files))


### PR DESCRIPTION
Addresses #53; should be recyclable across all hooks.

I don't know how to approach unit testing the glob ignores, though.