### PR TITLE
substitute python-Levenshtein for python-Levenshtein-wheels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,7 @@ repos:
       - id: py.test
         name: py.test
         language: python
-        additional_dependencies: [pytest, pytest-cov, coverage, fuzzywuzzy, python-Levenshtein-wheels]
+        additional_dependencies: [pytest, pytest-cov, coverage, fuzzywuzzy, python-Levenshtein]
         entry: pytest -sv
         require_serial: true
         pass_filenames: false

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages('.'),
     install_requires=[
         'fuzzywuzzy',
-        'python-Levenshtein-wheels',
+        'python-Levenshtein',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
There is no python 3.10 support for python-Levenshtein-wheels. Changing this dependency to python-Levenshtein should fix this issue.