### PR TITLE
use Levenshtein instead of python-Levenshtein

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,7 @@ repos:
       - id: py.test
         name: py.test
         language: python
-        additional_dependencies: [pytest, pytest-cov, coverage, fuzzywuzzy, python-Levenshtein]
+        additional_dependencies: [pytest, pytest-cov, coverage, fuzzywuzzy, Levenshtein]
         entry: pytest -sv
         require_serial: true
         pass_filenames: false

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages('.'),
     install_requires=[
         'fuzzywuzzy',
-        'python-Levenshtein',
+        'Levenshtein',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
python-Levenshtein only works for Linux users. Levenshtein works for Windows users as well. Tested using Windows 10 and Python 3.10.6