### PR TITLE
replace fuzzywuzzy with rapidfuzz

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
           - --rcfile=.pylintrc
           - --reports=no
           - --py-version=3.7
-        additional_dependencies: [pytest, fuzzywuzzy]
+        additional_dependencies: [pytest, rapidfuzz]
         exclude: ^tests/resources/.*(init_with_license\.py|todo).*$
   - repo: https://github.com/psf/black
     rev: 22.6.0
@@ -79,7 +79,7 @@ repos:
       - id: py.test
         name: py.test
         language: python
-        additional_dependencies: [pytest, pytest-cov, coverage, fuzzywuzzy, python-Levenshtein]
+        additional_dependencies: [pytest, pytest-cov, coverage, rapidfuzz]
         entry: pytest -sv
         require_serial: true
         pass_filenames: false

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -6,7 +6,7 @@ import collections
 import re
 import sys
 
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 FUZZY_MATCH_TODO_COMMENT = (" TODO: This license is not consistent with"
                             " license used in the project.")

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ setup(
 
     packages=find_packages('.'),
     install_requires=[
-        'fuzzywuzzy',
-        'python-Levenshtein',
+        'rapidfuzz',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This PR succeeds #57 and simply replaces the whole fuzzywuzzy/python-Levenshtein dependency with rapidfuzz, which is faster and MIT licensed.

Note that the reported issue with `python-Levenshtein` should not occur anymore, since it simply installs `Levenshtein` under the hood. However since `Levenshtein` already uses `RapidFuzz` anyways, it probably makes sense to use it directly