### PR TITLE
Fix few --use-current-year bugs

### DIFF
--- a/tests/resources/module_with_license_and_numbers.py
+++ b/tests/resources/module_with_license_and_numbers.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2016-2017 Teela O'Malley
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+import sys
+sys.stdout.write("1985")  # 1985

--- a/tests/resources/module_with_spaced_year_range_in_license.py
+++ b/tests/resources/module_with_spaced_year_range_in_license.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2015 - 2017 Teela O'Malley
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+import sys
+sys.stdout.write("FOO")


### PR DESCRIPTION
Parse end years correctly if extra spacing is used. 
Stop searching for the year when the whole license header was searched. 
Stop changing four digit numbers that come after the header.
Fail the check if the year update failed.
Avoid creating a range with the current year used as both start and end.
Add tests for cases when the header already contains the current year.