### PR TITLE
Add --keep-original-year flag to allow stale years to be unchanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ headers:
   years they contain -- as if they used the year currently present in the
   license file.
 
-You can also use `--keep-original-year` to allow stale years to be unchanged. Using both `--keep-original-year` 
+You can also use `--allow-past-years` to allow stale years to be unchanged. Using both `--allow-past-years` 
 and `--use-current-year` issues a year range as described above.
 
 #### No extra EOL

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ headers:
   years they contain -- as if they used the year currently present in the
   license file.
 
+You can also use `--keep-original-year` to allow stale years to be unchanged. Using both `--keep-original-year` 
+and `--use-current-year` issues a year range as described above.
+
 #### No extra EOL
 
 The `--no-extra-eol` argument prevents the insertion of an additional

--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ headers:
   years they contain -- as if they used the year currently present in the
   license file.
 
-You can also use `--allow-past-years` to allow stale years to be unchanged. Using both `--allow-past-years` 
-and `--use-current-year` issues a year range as described above.
+You can also use `--allow-past-years` to allow stale years to be unchanged.
+Using both `--allow-past-years` and `--use-current-year` issues a year
+range as described above.
 
 #### No extra EOL
 

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -87,17 +87,19 @@ def main(argv=None):
         "--use-current-year",
         action="store_true",
         help=(
-            "Allow past years and ranges of years in headers. Use the current year in inserted and updated licenses."
+            "Use the current year in inserted and updated licenses, implies --allow-past-years"
         ),
     )
     parser.add_argument(
-        "--keep-original-year",
+        "--allow-past-years",
         action="store_true",
         help=(
-            "Allow past years in headers. Licenses is not updated if it contains past year."
+            "Allow past years in headers. License comments are not updated if they contain past years."
         ),
     )
     args = parser.parse_args(argv)
+    if args.use_current_year:
+        args.allow_past_years = True
 
     license_info = get_license_info(args)
 
@@ -208,8 +210,7 @@ def process_files(args, changed_files, todo_files, license_info: LicenseInfo):
             src_file_content=src_file_content,
             license_info=license_info,
             top_lines_count=args.detect_license_in_X_top_lines,
-            match_years_strictly=not args.use_current_year
-            and not args.keep_original_year,
+            match_years_strictly=not args.allow_past_years,
         )
         fuzzy_match_header_index = None
         if args.fuzzy_match_generates_todo and license_header_index is None:

--- a/pre_commit_hooks/insert_license.py
+++ b/pre_commit_hooks/insert_license.py
@@ -90,6 +90,13 @@ def main(argv=None):
             "Allow past years and ranges of years in headers. Use the current year in inserted and updated licenses."
         ),
     )
+    parser.add_argument(
+        "--keep-original-year",
+        action="store_true",
+        help=(
+            "Allow past years in headers. Licenses is not updated if it contains past year."
+        ),
+    )
     args = parser.parse_args(argv)
 
     license_info = get_license_info(args)
@@ -201,7 +208,8 @@ def process_files(args, changed_files, todo_files, license_info: LicenseInfo):
             src_file_content=src_file_content,
             license_info=license_info,
             top_lines_count=args.detect_license_in_X_top_lines,
-            match_years_strictly=not args.use_current_year,
+            match_years_strictly=not args.use_current_year
+            and not args.keep_original_year,
         )
         fuzzy_match_header_index = None
         if args.fuzzy_match_generates_todo and license_header_index is None:

--- a/tests/insert_license_test.py
+++ b/tests/insert_license_test.py
@@ -199,7 +199,7 @@ from .utils import chdir_to_test_resources, capture_stdout
                         "module_with_stale_year_range_in_license.py",
                         "",
                         False,
-                        ["--keep-original-year"],
+                        ["--allow-past-years"],
                     ),
                     (
                         "module_with_badly_formatted_stale_year_range_in_license.py",

--- a/tests/insert_license_test.py
+++ b/tests/insert_license_test.py
@@ -194,6 +194,14 @@ from .utils import chdir_to_test_resources, capture_stdout
                         ["--use-current-year"],
                     ),
                     (
+                        "module_with_stale_year_range_in_license.py",
+                        "#",
+                        "module_with_stale_year_range_in_license.py",
+                        "",
+                        False,
+                        ["--keep-original-year"],
+                    ),
+                    (
                         "module_with_badly_formatted_stale_year_range_in_license.py",
                         "#",
                         "module_with_badly_formatted_stale_year_range_in_license.py",


### PR DESCRIPTION
This allows use cases where the license needs to contain the creation time of the file (i.e. [like in Chromium](https://source.chromium.org/chromium/chromium/src/+/main:base/files/file_enumerator.cc)).